### PR TITLE
Add sdcf4j command

### DIFF
--- a/src/main/java/org/javacord/bot/Main.java
+++ b/src/main/java/org/javacord/bot/Main.java
@@ -12,6 +12,7 @@ import org.javacord.bot.commands.GitHubCommand;
 import org.javacord.bot.commands.GradleCommand;
 import org.javacord.bot.commands.InviteCommand;
 import org.javacord.bot.commands.MavenCommand;
+import org.javacord.bot.commands.Sdcf4jCommand;
 import org.javacord.bot.commands.SetupCommand;
 import org.javacord.bot.commands.WikiCommand;
 
@@ -40,6 +41,7 @@ public class Main {
         handler.registerCommand(new MavenCommand());
         handler.registerCommand(new SetupCommand());
         handler.registerCommand(new WikiCommand());
+        handler.registerCommand(new Sdcf4jCommand());
     }
 
 }

--- a/src/main/java/org/javacord/bot/commands/Sdcf4jCommand.java
+++ b/src/main/java/org/javacord/bot/commands/Sdcf4jCommand.java
@@ -1,0 +1,23 @@
+package org.javacord.bot.commands;
+
+import de.btobastian.sdcf4j.Command;
+import de.btobastian.sdcf4j.CommandExecutor;
+import org.javacord.api.entity.channel.TextChannel;
+import org.javacord.api.entity.message.embed.EmbedBuilder;
+import org.javacord.bot.Constants;
+
+public class Sdcf4jCommand implements CommandExecutor {
+
+    @Command(aliases = {"!sdcf4j", "!commands"}, async = true)
+    public void onCommand(TextChannel channel) {
+
+        EmbedBuilder embed = new EmbedBuilder()
+                .setTitle("SDCF4J")
+                .setDescription("A simple discord command framework, compatible with Javacord, JDA and Discord4J")
+                .addInlineField("GitHub", "https://github.com/Bastian/sdcf4j")
+                .addInlineField("Wiki", "https://github.com/Bastian/sdcf4j/wiki")
+                .setColor(Constants.JAVACORD_ORANGE);
+        channel.sendMessage(embed).join();
+    }
+
+}


### PR DESCRIPTION
Without the javacord logo.

This displays basic information about sdcf4j on demand.