### PR TITLE
Enable runtime logging changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,3 +51,19 @@ checkstyle {
     toolVersion versions.checkstyle
     maxWarnings 0
 }
+
+applicationDefaultJvmArgs = ['-Dlog4j.configurationFile=%APP_HOME%/config/log4j2.xml']
+startScripts.doLast {
+    unixScript.text = unixScript.text.replace('%APP_HOME%', '$APP_HOME')
+    windowsScript.text = windowsScript.text.replace('%%APP_HOME%%', '%APP_HOME%')
+}
+
+distributions {
+    main {
+        contents {
+            from ('src/main/resources/log4j2.xml') {
+                into 'config'
+            }
+        }
+    }
+}

--- a/src/main/java/org/javacord/bot/Main.java
+++ b/src/main/java/org/javacord/bot/Main.java
@@ -28,9 +28,17 @@ public class Main {
      *
      * @param args The bot requires exactly one argument, either a file with the token as content or the token directly.
      *             If the argument is a relative file path, it is relative to the working directory.
-     * @throws IOException If there is an error when reading the token file.
+     * @throws IOException If there is an error when reading the token file or writing the default log4j2.xml.
      */
     public static void main(String[] args) throws IOException {
+        String log4jConfigurationFileProperty = System.getProperty("log4j.configurationFile");
+        if (log4jConfigurationFileProperty != null) {
+            Path log4jConfigurationFile = Paths.get(log4jConfigurationFileProperty);
+            if (!Files.exists(log4jConfigurationFile)) {
+                Files.copy(Main.class.getResourceAsStream("/log4j2.xml"), log4jConfigurationFile);
+            }
+        }
+
         Thread.setDefaultUncaughtExceptionHandler(ExceptionLogger.getUncaughtExceptionHandler());
 
         if (args.length != 1) {

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,13 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN">
+<Configuration name="Javacord Bot" status="INFO" monitorInterval="5" strict="true">
     <Appenders>
-        <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        <Console name="Console Appender">
+            <PatternLayout disableAnsi="false">
+                <Pattern><![CDATA[%highlight{%d <%-5p> <%-35.35t> <%x> <%X> <%50.50c> %m}%n]]></Pattern>
+            </PatternLayout>
         </Console>
+        <File name="File Appender" fileName="log/javacord-bot.log" createOnDemand="true">
+            <PatternLayout>
+                <Pattern><![CDATA[%d <%-5p> <%-35.35t> <%x> <%X> <%50.50c> %m%n]]></Pattern>
+            </PatternLayout>
+        </File>
     </Appenders>
     <Loggers>
-        <Root level="debug">
-            <AppenderRef ref="Console"/>
+        <Root level="DEBUG">
+            <AppenderRef ref="Console Appender"/>
+            <!--<AppenderRef ref="File Appender"/>-->
         </Root>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
The log4j configuration file is now placed as stand-alone file in the distribution package.
This makes it possible to change logging configuration during runtime.
Also the log pattern was a bit improved and logging to a file prepared.