### PR TITLE
Logging improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:${versions.okhttp}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"
     implementation "org.apache.logging.log4j:log4j-api:${versions.log4j}"
+    implementation "org.apache.logging.log4j:log4j-jul:${versions.log4j}"
 
     runtimeOnly "org.apache.logging.log4j:log4j-core:${versions.log4j}"
     runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:${versions.log4j}"

--- a/build.gradle
+++ b/build.gradle
@@ -68,10 +68,12 @@ checkstyle {
     maxWarnings 0
 }
 
-applicationDefaultJvmArgs = ['-Dlog4j.configurationFile=%APP_HOME%/config/log4j2.xml']
-startScripts.doLast {
-    unixScript.text = unixScript.text.replace('%APP_HOME%', '$APP_HOME')
-    windowsScript.text = windowsScript.text.replace('%%APP_HOME%%', '%APP_HOME%')
+startScripts {
+    defaultJvmOpts = ['-Dlog4j.configurationFile=%APP_HOME%/config/log4j2.xml']
+    doLast {
+        unixScript.text = unixScript.text.replace('%APP_HOME%', '$APP_HOME')
+        windowsScript.text = windowsScript.text.replace('%%APP_HOME%%', '%APP_HOME%')
+    }
 }
 
 distributions {

--- a/src/main/java/org/javacord/bot/Main.java
+++ b/src/main/java/org/javacord/bot/Main.java
@@ -31,15 +31,7 @@ public class Main {
      * @throws IOException If there is an error when reading the token file or writing the default log4j2.xml.
      */
     public static void main(String[] args) throws IOException {
-        String log4jConfigurationFileProperty = System.getProperty("log4j.configurationFile");
-        if (log4jConfigurationFileProperty != null) {
-            Path log4jConfigurationFile = Paths.get(log4jConfigurationFileProperty);
-            if (!Files.exists(log4jConfigurationFile)) {
-                Files.copy(Main.class.getResourceAsStream("/log4j2.xml"), log4jConfigurationFile);
-            }
-        }
-
-        Thread.setDefaultUncaughtExceptionHandler(ExceptionLogger.getUncaughtExceptionHandler());
+        setupLogging();
 
         if (args.length != 1) {
             System.err.println("This bot requires exactly one argument, "
@@ -75,6 +67,20 @@ public class Main {
         handler.registerCommand(new WikiCommand());
         handler.registerCommand(new Sdcf4jCommand());
         handler.registerCommand(new InfoCommand());
+    }
+
+    private static void setupLogging() throws IOException {
+        System.setProperty("java.util.logging.manager", org.apache.logging.log4j.jul.LogManager.class.getName());
+
+        String log4jConfigurationFileProperty = System.getProperty("log4j.configurationFile");
+        if (log4jConfigurationFileProperty != null) {
+            Path log4jConfigurationFile = Paths.get(log4jConfigurationFileProperty);
+            if (!Files.exists(log4jConfigurationFile)) {
+                Files.copy(Main.class.getResourceAsStream("/log4j2.xml"), log4jConfigurationFile);
+            }
+        }
+
+        Thread.setDefaultUncaughtExceptionHandler(ExceptionLogger.getUncaughtExceptionHandler());
     }
 
 }


### PR DESCRIPTION
- Capture the java.util.logging messages that are for example used by OkHttp
- Do not set the log4j configuration file for 'run' task