### PR TITLE
Fix resource leaks from unclosed Autocloseables

### DIFF
--- a/src/main/java/org/javacord/bot/Main.java
+++ b/src/main/java/org/javacord/bot/Main.java
@@ -16,7 +16,9 @@ import org.javacord.bot.commands.Sdcf4jCommand;
 import org.javacord.bot.commands.SetupCommand;
 import org.javacord.bot.commands.WikiCommand;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -45,7 +47,9 @@ public class Main {
         // Token
         Path tokenFile = Paths.get(args[0]);
         if (Files.isRegularFile(tokenFile)) {
-            apiBuilder.setToken(Files.newBufferedReader(tokenFile).readLine());
+            try (BufferedReader tokenFileReader = Files.newBufferedReader(tokenFile)) {
+                apiBuilder.setToken(tokenFileReader.readLine());
+            }
         } else {
             apiBuilder.setToken(args[0]);
         }
@@ -76,7 +80,9 @@ public class Main {
         if (log4jConfigurationFileProperty != null) {
             Path log4jConfigurationFile = Paths.get(log4jConfigurationFileProperty);
             if (!Files.exists(log4jConfigurationFile)) {
-                Files.copy(Main.class.getResourceAsStream("/log4j2.xml"), log4jConfigurationFile);
+                try (InputStream fallbackLog4j2ConfigStream = Main.class.getResourceAsStream("/log4j2.xml")) {
+                    Files.copy(fallbackLog4j2ConfigStream, log4jConfigurationFile);
+                }
             }
         }
 

--- a/src/main/java/org/javacord/bot/commands/DocsCommand.java
+++ b/src/main/java/org/javacord/bot/commands/DocsCommand.java
@@ -11,6 +11,8 @@ import org.javacord.bot.util.javadoc.parser.JavadocClass;
 import org.javacord.bot.util.javadoc.parser.JavadocMethod;
 import org.javacord.bot.util.javadoc.parser.JavadocParser;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -27,23 +29,20 @@ public class DocsCommand implements CommandExecutor {
      *
      * @param channel The channel where the command was issued.
      * @param args    The arguments given to the command.
+     * @throws IOException If the Javacord icon stream cannot be closed properly.
      */
     @Command(aliases = {"!docs"}, async = true)
-    public void onCommand(TextChannel channel, String[] args) {
-        try {
+    public void onCommand(TextChannel channel, String[] args) throws IOException {
+        try (InputStream javacord3Icon = getClass().getClassLoader().getResourceAsStream("javacord3_icon.png")) {
+            EmbedBuilder embed = new EmbedBuilder()
+                    .setThumbnail(javacord3Icon, "png")
+                    .setColor(Constants.JAVACORD_ORANGE);
             if (args.length == 0) { // Just give an overview
-                EmbedBuilder embed = new EmbedBuilder()
-                        .addField("Overview", "https://docs.javacord.org/")
+                embed.addField("Overview", "https://docs.javacord.org/")
                         .addField("Latest release version", "https://docs.javacord.org/api/v/latest")
                         .addField("Latest snapshot", "https://docs.javacord.org/api/build/latest")
-                        .addField("Hint", "You can search the docs using `!docs [method|class] <search>`")
-                        .setThumbnail(getClass().getClassLoader().getResourceAsStream("javacord3_icon.png"), "png")
-                        .setColor(Constants.JAVACORD_ORANGE);
-                channel.sendMessage(embed).join();
+                        .addField("Hint", "You can search the docs using `!docs [method|class] <search>`");
             } else { // Search
-                EmbedBuilder embed = new EmbedBuilder()
-                        .setThumbnail(getClass().getClassLoader().getResourceAsStream("javacord3_icon.png"), "png")
-                        .setColor(Constants.JAVACORD_ORANGE);
                 if (args[0].matches("(classes|class|c)")) { // Search for a class
                     String searchString = String.join(" ", Arrays.copyOfRange(args, 1, args.length));
                     populateClasses(channel.getApi(), embed, searchString);
@@ -54,8 +53,8 @@ public class DocsCommand implements CommandExecutor {
                     String searchString = String.join(" ", args);
                     populateMethods(channel.getApi(), embed, searchString);
                 }
-                channel.sendMessage(embed).join();
             }
+            channel.sendMessage(embed).join();
         } catch (Throwable t) {
             channel.sendMessage(
                     "Something went wrong: ```" + ExceptionLogger.unwrapThrowable(t).getMessage() + "```").join();

--- a/src/main/java/org/javacord/bot/commands/ExampleCommand.java
+++ b/src/main/java/org/javacord/bot/commands/ExampleCommand.java
@@ -6,6 +6,9 @@ import org.javacord.api.entity.channel.TextChannel;
 import org.javacord.api.entity.message.embed.EmbedBuilder;
 import org.javacord.bot.Constants;
 
+import java.io.IOException;
+import java.io.InputStream;
+
 /**
  * The !example command which is used to get an link to the example bot.
  */
@@ -15,15 +18,18 @@ public class ExampleCommand implements CommandExecutor {
      * Executes the {@code !example} command.
      *
      * @param channel The channel where the command was issued.
+     * @throws IOException If the Javacord icon stream cannot be closed properly.
      */
     @Command(aliases = {"!example"}, async = true)
-    public void onCommand(TextChannel channel) {
-        EmbedBuilder embed = new EmbedBuilder()
-                .setThumbnail(getClass().getClassLoader().getResourceAsStream("javacord3_icon.png"), "png")
-                .setColor(Constants.JAVACORD_ORANGE)
-                .addField("Example Bot", "https://github.com/Javacord/Example-Bot");
+    public void onCommand(TextChannel channel) throws IOException {
+        try (InputStream javacord3Icon = getClass().getClassLoader().getResourceAsStream("javacord3_icon.png")) {
+            EmbedBuilder embed = new EmbedBuilder()
+                    .setThumbnail(javacord3Icon, "png")
+                    .setColor(Constants.JAVACORD_ORANGE)
+                    .addField("Example Bot", "https://github.com/Javacord/Example-Bot");
 
-        channel.sendMessage(embed).join();
+            channel.sendMessage(embed).join();
+        }
     }
 
 }

--- a/src/main/java/org/javacord/bot/commands/GitHubCommand.java
+++ b/src/main/java/org/javacord/bot/commands/GitHubCommand.java
@@ -6,6 +6,9 @@ import org.javacord.api.entity.channel.TextChannel;
 import org.javacord.api.entity.message.embed.EmbedBuilder;
 import org.javacord.bot.Constants;
 
+import java.io.IOException;
+import java.io.InputStream;
+
 /**
  * The !github command which is used to link to Javacord related GitHub repositories.
  */
@@ -15,15 +18,18 @@ public class GitHubCommand implements CommandExecutor {
      * Executes the {@code !github} command.
      *
      * @param channel The channel where the command was issued.
+     * @throws IOException If the Javacord icon stream cannot be closed properly.
      */
     @Command(aliases = {"!github"}, async = true)
-    public void onCommand(TextChannel channel) {
-        EmbedBuilder embed = new EmbedBuilder()
-                .addField("Javacord", "https://github.com/Javacord/Javacord")
-                .addField("Example Bot", "https://github.com/Javacord/Example-Bot")
-                .setThumbnail(getClass().getClassLoader().getResourceAsStream("javacord3_icon.png"), "png")
-                .setColor(Constants.JAVACORD_ORANGE);
-        channel.sendMessage(embed).join();
+    public void onCommand(TextChannel channel) throws IOException {
+        try (InputStream javacord3Icon = getClass().getClassLoader().getResourceAsStream("javacord3_icon.png")) {
+            EmbedBuilder embed = new EmbedBuilder()
+                    .addField("Javacord", "https://github.com/Javacord/Javacord")
+                    .addField("Example Bot", "https://github.com/Javacord/Example-Bot")
+                    .setThumbnail(javacord3Icon, "png")
+                    .setColor(Constants.JAVACORD_ORANGE);
+            channel.sendMessage(embed).join();
+        }
     }
 
 }

--- a/src/main/java/org/javacord/bot/commands/InviteCommand.java
+++ b/src/main/java/org/javacord/bot/commands/InviteCommand.java
@@ -6,6 +6,9 @@ import org.javacord.api.entity.channel.TextChannel;
 import org.javacord.api.entity.message.embed.EmbedBuilder;
 import org.javacord.bot.Constants;
 
+import java.io.IOException;
+import java.io.InputStream;
+
 /**
  * The !invite command which is used to get an invite link to the Javacord Discord server.
  */
@@ -15,15 +18,18 @@ public class InviteCommand implements CommandExecutor {
      * Executes the {@code !invite} command.
      *
      * @param channel The channel where the command was issued.
+     * @throws IOException If the Javacord icon stream cannot be closed properly.
      */
     @Command(aliases = {"!invite"}, async = true)
-    public void onCommand(TextChannel channel) {
-        EmbedBuilder embed = new EmbedBuilder()
-                .setThumbnail(getClass().getClassLoader().getResourceAsStream("javacord3_icon.png"), "png")
-                .setColor(Constants.JAVACORD_ORANGE)
-                .addField("Invite Link", "https://discordapp.com/invite/0qJ2jjyneLEgG7y3");
+    public void onCommand(TextChannel channel) throws IOException {
+        try (InputStream javacord3Icon = getClass().getClassLoader().getResourceAsStream("javacord3_icon.png")) {
+            EmbedBuilder embed = new EmbedBuilder()
+                    .setThumbnail(javacord3Icon, "png")
+                    .setColor(Constants.JAVACORD_ORANGE)
+                    .addField("Invite Link", "https://discordapp.com/invite/0qJ2jjyneLEgG7y3");
 
-        channel.sendMessage(embed).join();
+            channel.sendMessage(embed).join();
+        }
     }
 
 }

--- a/src/main/java/org/javacord/bot/commands/WikiCommand.java
+++ b/src/main/java/org/javacord/bot/commands/WikiCommand.java
@@ -11,6 +11,7 @@ import org.javacord.bot.util.wiki.parser.WikiPage;
 import org.javacord.bot.util.wiki.parser.WikiParser;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
@@ -34,20 +35,16 @@ public class WikiCommand implements CommandExecutor {
      */
     @Command(aliases = {"!wiki"}, async = true)
     public void onCommand(DiscordApi api, TextChannel channel, String[] args) throws IOException {
-        try {
+        try (InputStream javacord3Icon = getClass().getClassLoader().getResourceAsStream("javacord3_icon.png")) {
+            EmbedBuilder embed = new EmbedBuilder()
+                    .setThumbnail(getClass().getClassLoader().getResourceAsStream("javacord3_icon.png"), "png")
+                    .setColor(Constants.JAVACORD_ORANGE);
             if (args.length == 0) { // Just an overview
-                EmbedBuilder embed = new EmbedBuilder()
-                        .setTitle("Javacord Wiki")
+                embed.setTitle("Javacord Wiki")
                         .setDescription("The [Javacord Wiki](" + WikiParser.BASE_URL + "/wiki) is an excellent "
                                 + "resource to get you started with Javacord.\n")
-                        .addInlineField("Hint", "You can search the wiki using `!wiki [title|full] <search>")
-                        .setThumbnail(getClass().getClassLoader().getResourceAsStream("javacord3_icon.png"), "png")
-                        .setColor(Constants.JAVACORD_ORANGE);
-                channel.sendMessage(embed).join();
+                        .addInlineField("Hint", "You can search the wiki using `!wiki [title|full] <search>");
             } else {
-                EmbedBuilder embed = new EmbedBuilder()
-                        .setThumbnail(getClass().getClassLoader().getResourceAsStream("javacord3_icon.png"), "png")
-                        .setColor(Constants.JAVACORD_ORANGE);
                 String searchString = String.join(" ", Arrays.copyOfRange(args, 1, args.length)).toLowerCase();
                 switch (args[0]) {
                     case "page":
@@ -66,8 +63,8 @@ public class WikiCommand implements CommandExecutor {
                         searchString = String.join(" ", Arrays.copyOfRange(args, 0, args.length)).toLowerCase();
                         populatePages(api, embed, defaultSearch(searchString));
                 }
-                channel.sendMessage(embed).join();
             }
+            channel.sendMessage(embed).join();
         } catch (Throwable t) {
             channel.sendMessage("Something went wrong: ```" + ExceptionLogger.unwrapThrowable(t).getMessage() + "```")
                     .join();

--- a/src/main/java/org/javacord/bot/util/javadoc/parser/JavadocParser.java
+++ b/src/main/java/org/javacord/bot/util/javadoc/parser/JavadocParser.java
@@ -49,8 +49,9 @@ public class JavadocParser {
                         .url("https://docs.javacord.org/api/")
                         .build();
 
-                Response response = client.newCall(request).execute();
-                return response.request().url().toString();
+                try (Response response = client.newCall(request).execute()) {
+                    return response.request().url().toString();
+                }
             } catch (Exception e) {
                 throw new CompletionException(e);
             }
@@ -99,15 +100,13 @@ public class JavadocParser {
                 .build();
 
         Response response = client.newCall(request).execute();
-        ResponseBody body = response.body();
-        Set<JavadocMethod> methods = new HashSet<>();
-        if (body == null) {
+        try (ResponseBody body = response.body()) {
+            Set<JavadocMethod> methods = new HashSet<>();
+            for (JsonNode node : mapper.readTree(body.string().replaceFirst("memberSearchIndex = ", ""))) {
+                methods.add(new JavadocMethod(url, node));
+            }
             return methods;
         }
-        for (JsonNode node : mapper.readTree(body.string().replaceFirst("memberSearchIndex = ", ""))) {
-            methods.add(new JavadocMethod(url, node));
-        }
-        return methods;
     }
 
     /**
@@ -122,15 +121,13 @@ public class JavadocParser {
                 .build();
 
         Response response = client.newCall(request).execute();
-        ResponseBody body = response.body();
-        Set<JavadocClass> classes = new HashSet<>();
-        if (body == null) {
+        try (ResponseBody body = response.body()) {
+            Set<JavadocClass> classes = new HashSet<>();
+            for (JsonNode node : mapper.readTree(body.string().replaceFirst("typeSearchIndex = ", ""))) {
+                classes.add(new JavadocClass(url, node));
+            }
             return classes;
         }
-        for (JsonNode node : mapper.readTree(body.string().replaceFirst("typeSearchIndex = ", ""))) {
-            classes.add(new JavadocClass(url, node));
-        }
-        return classes;
     }
 
 }


### PR DESCRIPTION
I've seen this in the logs frequently:

```log
2018-11-25 07:02:15,351 <WARN > <OkHttp ConnectionPool              > <[]> <{shard=0}> <                              okhttp3.OkHttpClient> A connection to https://docs.javacord.org/ was leaked. Did you forget to close a response body? To see where this was allocated, set the OkHttpClient logger level to FINE: Logger.getLogger(OkHttpClient.class.getName()).setLevel(Level.FINE);
2018-11-26 02:47:45,682 <WARN > <OkHttp ConnectionPool              > <[]> <{shard=0}> <                              okhttp3.OkHttpClient> A connection to https://docs.javacord.org/ was leaked. Did you forget to close a response body? To see where this was allocated, set the OkHttpClient logger level to FINE: Logger.getLogger(OkHttpClient.class.getName()).setLevel(Level.FINE);
2018-11-26 19:41:32,710 <WARN > <OkHttp ConnectionPool              > <[]> <{shard=0}> <                              okhttp3.OkHttpClient> A connection to https://docs.javacord.org/ was leaked. Did you forget to close a response body? To see where this was allocated, set the OkHttpClient logger level to FINE: Logger.getLogger(OkHttpClient.class.getName()).setLevel(Level.FINE);
2018-11-26 19:46:32,712 <WARN > <OkHttp ConnectionPool              > <[]> <{shard=0}> <                              okhttp3.OkHttpClient> A connection to https://docs.javacord.org/ was leaked. Did you forget to close a response body? To see where this was allocated, set the OkHttpClient logger level to FINE: Logger.getLogger(OkHttpClient.class.getName()).setLevel(Level.FINE);
```

So I searched for unclosed `AutoCloseable`s in the bot code and fixed the places.