### PR TITLE
Obtain latest release version dynamically and use where appropriate

### DIFF
--- a/src/main/java/org/javacord/bot/Constants.java
+++ b/src/main/java/org/javacord/bot/Constants.java
@@ -22,6 +22,11 @@ public final class Constants {
      */
     public static final long DAPI_JAVACORD_CHANNEL_ID = 381889796785831936L;
 
+    /**
+     * The API URL where to obtain the latest release version for Javacord.
+     */
+    public static final String LATEST_VERSION_URL = "https://docs.javacord.org/rest/latest-version/release";
+
     private Constants() { /* nope */ }
 
 }

--- a/src/main/java/org/javacord/bot/Main.java
+++ b/src/main/java/org/javacord/bot/Main.java
@@ -16,6 +16,7 @@ import org.javacord.bot.commands.Sdcf4jCommand;
 import org.javacord.bot.commands.SetupCommand;
 import org.javacord.bot.commands.WikiCommand;
 import org.javacord.bot.listeners.CommandCleanupListener;
+import org.javacord.bot.util.LatestVersionFinder;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -60,15 +61,18 @@ public class Main {
                 .setWaitForServersOnStartup(false)
                 .login().join();
 
+        // Tool for finding the latest version.
+        LatestVersionFinder versionFinder = new LatestVersionFinder(api);
+
         // Register commands
         CommandHandler handler = new JavacordHandler(api);
         handler.registerCommand(new DocsCommand());
         handler.registerCommand(new ExampleCommand());
         handler.registerCommand(new GitHubCommand());
-        handler.registerCommand(new GradleCommand());
+        handler.registerCommand(new GradleCommand(versionFinder));
         handler.registerCommand(new InviteCommand());
-        handler.registerCommand(new MavenCommand());
-        handler.registerCommand(new SetupCommand());
+        handler.registerCommand(new MavenCommand(versionFinder));
+        handler.registerCommand(new SetupCommand(versionFinder));
         handler.registerCommand(new WikiCommand());
         handler.registerCommand(new Sdcf4jCommand());
         handler.registerCommand(new InfoCommand());

--- a/src/main/java/org/javacord/bot/commands/GradleCommand.java
+++ b/src/main/java/org/javacord/bot/commands/GradleCommand.java
@@ -2,18 +2,28 @@ package org.javacord.bot.commands;
 
 import de.btobastian.sdcf4j.Command;
 import de.btobastian.sdcf4j.CommandExecutor;
-import org.javacord.api.Javacord;
 import org.javacord.api.entity.channel.TextChannel;
 import org.javacord.api.entity.message.Message;
 import org.javacord.api.entity.message.embed.EmbedBuilder;
 import org.javacord.api.entity.server.Server;
 import org.javacord.bot.Constants;
 import org.javacord.bot.listeners.CommandCleanupListener;
+import org.javacord.bot.util.LatestVersionFinder;
 
 /**
  * The !gradle command which is used to get information about Javacord with Gradle.
  */
 public class GradleCommand implements CommandExecutor {
+
+    private final LatestVersionFinder versionFinder;
+
+    /**
+     * Initializes the command.
+     * @param versionFinder The version finder to use to determine the latest javacord version.
+     */
+    public GradleCommand(LatestVersionFinder versionFinder) {
+        this.versionFinder = versionFinder;
+    }
 
     /**
      * Executes the {@code !gradle} command.
@@ -29,6 +39,7 @@ public class GradleCommand implements CommandExecutor {
             return;
         }
 
+        String latestVersion = versionFinder.findLatestVersion().join();
         EmbedBuilder embed = new EmbedBuilder()
                 .setColor(Constants.JAVACORD_ORANGE)
                 .addField("Dependency",
@@ -37,8 +48,7 @@ public class GradleCommand implements CommandExecutor {
                                 + "  mavenCentral()\n"
                                 + "}\n"
                                 + "dependencies { \n"
-                                // TODO Always use the latest version
-                                + "  implementation 'org.javacord:javacord:" + Javacord.VERSION + "'\n"
+                                + "  implementation 'org.javacord:javacord:" + latestVersion + "'\n"
                                 + "}\n"
                                 + "```")
                 .addField("Setup Guide", "• [IntelliJ](https://javacord.org/wiki/getting-started/intellij-gradle/)");

--- a/src/main/java/org/javacord/bot/commands/MavenCommand.java
+++ b/src/main/java/org/javacord/bot/commands/MavenCommand.java
@@ -2,18 +2,28 @@ package org.javacord.bot.commands;
 
 import de.btobastian.sdcf4j.Command;
 import de.btobastian.sdcf4j.CommandExecutor;
-import org.javacord.api.Javacord;
 import org.javacord.api.entity.channel.TextChannel;
 import org.javacord.api.entity.message.Message;
 import org.javacord.api.entity.message.embed.EmbedBuilder;
 import org.javacord.api.entity.server.Server;
 import org.javacord.bot.Constants;
 import org.javacord.bot.listeners.CommandCleanupListener;
+import org.javacord.bot.util.LatestVersionFinder;
 
 /**
  * The !maven command which is used to get information about Javacord with Maven.
  */
 public class MavenCommand implements CommandExecutor {
+
+    private final LatestVersionFinder versionFinder;
+
+    /**
+     * Initializes the Command.
+     * @param versionFinder The version finder to use to determine the latest javacord version.
+     */
+    public MavenCommand(LatestVersionFinder versionFinder) {
+        this.versionFinder = versionFinder;
+    }
 
     /**
      * Executes the {@code !maven} command.
@@ -29,6 +39,7 @@ public class MavenCommand implements CommandExecutor {
             return;
         }
 
+        String latestVersion = versionFinder.findLatestVersion().join();
         EmbedBuilder embed = new EmbedBuilder()
                 .setColor(Constants.JAVACORD_ORANGE)
                 .addField("Dependency",
@@ -36,8 +47,7 @@ public class MavenCommand implements CommandExecutor {
                                 + "<dependency>\n"
                                 + "    <groupId>org.javacord</groupId>\n"
                                 + "    <artifactId>javacord</artifactId>\n"
-                                // TODO Always use the latest version
-                                + "    <version>" + Javacord.VERSION + "</version>\n"
+                                + "    <version>" + latestVersion + "</version>\n"
                                 + "    <type>pom</type>\n"
                                 + "</dependency>\n"
                                 + "```")

--- a/src/main/java/org/javacord/bot/commands/SetupCommand.java
+++ b/src/main/java/org/javacord/bot/commands/SetupCommand.java
@@ -8,11 +8,22 @@ import org.javacord.api.entity.message.embed.EmbedBuilder;
 import org.javacord.api.entity.server.Server;
 import org.javacord.bot.Constants;
 import org.javacord.bot.listeners.CommandCleanupListener;
+import org.javacord.bot.util.LatestVersionFinder;
 
 /**
  * The !setup command which is used to get information useful for first setup.
  */
 public class SetupCommand implements CommandExecutor {
+
+    private final LatestVersionFinder versionFinder;
+
+    /**
+     * Initializes the Command.
+     * @param versionFinder The version finder to use to determine the latest javacord version.
+     */
+    public SetupCommand(LatestVersionFinder versionFinder) {
+        this.versionFinder = versionFinder;
+    }
 
     /**
      * Executes the {@code !setup} command.
@@ -27,7 +38,7 @@ public class SetupCommand implements CommandExecutor {
         if ((server.getId() == Constants.DAPI_SERVER_ID) && (channel.getId() != Constants.DAPI_JAVACORD_CHANNEL_ID)) {
             return;
         }
-
+        String latestVersion = versionFinder.findLatestVersion().join();
         EmbedBuilder embed = new EmbedBuilder()
                 .setColor(Constants.JAVACORD_ORANGE)
                 .addField("Gradle Dependency",
@@ -36,8 +47,7 @@ public class SetupCommand implements CommandExecutor {
                                 + "  mavenCentral()\n"
                                 + "}\n"
                                 + "dependencies { \n"
-                                // TODO Always use the latest version
-                                + "  implementation 'org.javacord:javacord:3.0.0'\n"
+                                + "  implementation 'org.javacord:javacord:" + latestVersion + "'\n"
                                 + "}\n"
                                 + "```")
                 .addField("Maven Dependency",
@@ -45,8 +55,7 @@ public class SetupCommand implements CommandExecutor {
                                 + "<dependency>\n"
                                 + "    <groupId>org.javacord</groupId>\n"
                                 + "    <artifactId>javacord</artifactId>\n"
-                                // TODO Always use the latest version
-                                + "    <version>3.0.0</version>\n"
+                                + "    <version>" + latestVersion + "</version>\n"
                                 + "    <type>pom</type>\n"
                                 + "</dependency>\n"
                                 + "```")

--- a/src/main/java/org/javacord/bot/util/LatestVersionFinder.java
+++ b/src/main/java/org/javacord/bot/util/LatestVersionFinder.java
@@ -1,0 +1,75 @@
+package org.javacord.bot.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.ResponseBody;
+import org.javacord.api.DiscordApi;
+import org.javacord.api.util.logging.ExceptionLogger;
+import org.javacord.bot.Constants;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+
+public class LatestVersionFinder {
+
+    private final DiscordApi api;
+
+    private static final OkHttpClient client = new OkHttpClient();
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private volatile String latestVersion = "";
+
+    /**
+     * Initialize the Version finder.
+     * @param api The api object of which to obtain the Scheduler.
+     */
+    public LatestVersionFinder(DiscordApi api) {
+        this.api = api;
+        // Populate with latest version
+        CompletableFuture.supplyAsync(this::getAndUpdateVersionSync, api.getThreadPool().getExecutorService())
+                .exceptionally(ExceptionLogger.get());
+    }
+
+    /**
+     * Obtain the latest release version of Javacord.
+     *
+     * <p>If the version cannot be obtained, the last successfully retrieved version will be used instead.
+     *
+     * @return The most recent release version.
+     */
+    public CompletableFuture<String> findLatestVersion() {
+        ExecutorService executorService = api.getThreadPool().getExecutorService();
+        return CompletableFuture.supplyAsync(this::getAndUpdateVersionSync, executorService)
+                .exceptionally(ExceptionLogger.get().andThen(value -> latestVersion));
+    }
+
+    private String getAndUpdateVersionSync() {
+        Request request = new Request.Builder()
+                .url(Constants.LATEST_VERSION_URL)
+                .build();
+        try (ResponseBody body = client.newCall(request).execute().body()) {
+            if (body == null) {
+                throw new RuntimeException("Error while requesting the latest version: No response body.");
+            }
+            JsonNode response = mapper.readTree(body.charStream());
+            // Response format is a JSON object {"version":"x.y.z"}
+            if (!response.isObject()) {
+                throw new AssertionError("Latest Version API result differs from expectation");
+            }
+            String latestVersion = response.get("version").asText();
+            if (latestVersion == null || latestVersion.isEmpty()) {
+                throw new AssertionError("Latest Version API result differs from expectation");
+            }
+            // Set cached version
+            this.latestVersion = latestVersion;
+            // Eventually clean up update task
+            return latestVersion;
+        } catch (NullPointerException | IOException e) {
+            throw new RuntimeException("Error while requesting the latest version", e);
+        }
+    }
+
+}


### PR DESCRIPTION
Implements #20 

Since the version is used in several commands I decided to implement a central cache so that the version will not be requested more than once every 10 minutes. That, of course, can be changed easily.