### PR TITLE
Removing "re: message_id"

### DIFF
--- a/src/main/java/org/javacord/bot/listeners/CommandCleanupListener.java
+++ b/src/main/java/org/javacord/bot/listeners/CommandCleanupListener.java
@@ -24,24 +24,8 @@ public class CommandCleanupListener implements MessageDeleteListener {
      * @return The embed builder for call chaining.
      */
     public static EmbedBuilder insertResponseTracker(EmbedBuilder builder, long trackedMessageId) {
-<<<<<<< HEAD
         return builder.setFooter(longToBinaryBlankString(trackedMessageId)
                                  + "If you delete your invocation message, this response will be deleted.");
-=======
-        return  insertResponseTracker(builder, trackedMessageId, "If you delete your invocation message, this will be deleted. 🥄");
-    }
-
-    /**
-     * Inserts a tracking footer into an embed builder.
-     *
-     * @param builder          The embed builder to change.
-     * @param trackedMessageId The id of the message to track.
-     * @param footerContent The content the Footer should display.
-     * @return The embed builder for call chaining.
-     */
-    public static EmbedBuilder insertResponseTracker(EmbedBuilder builder, long trackedMessageId, String footerContent) {
-        return builder.setFooter(longToBinaryBlankString(trackedMessageId) + footerContent);
->>>>>>> parent of 6a41e47... Update CommandCleanupListener.java
     }
 
     @Override

--- a/src/main/java/org/javacord/bot/listeners/CommandCleanupListener.java
+++ b/src/main/java/org/javacord/bot/listeners/CommandCleanupListener.java
@@ -24,8 +24,24 @@ public class CommandCleanupListener implements MessageDeleteListener {
      * @return The embed builder for call chaining.
      */
     public static EmbedBuilder insertResponseTracker(EmbedBuilder builder, long trackedMessageId) {
+<<<<<<< HEAD
         return builder.setFooter(longToBinaryBlankString(trackedMessageId)
                                  + "If you delete your invocation message, this response will be deleted.");
+=======
+        return  insertResponseTracker(builder, trackedMessageId, "If you delete your invocation message, this will be deleted. 🥄");
+    }
+
+    /**
+     * Inserts a tracking footer into an embed builder.
+     *
+     * @param builder          The embed builder to change.
+     * @param trackedMessageId The id of the message to track.
+     * @param footerContent The content the Footer should display.
+     * @return The embed builder for call chaining.
+     */
+    public static EmbedBuilder insertResponseTracker(EmbedBuilder builder, long trackedMessageId, String footerContent) {
+        return builder.setFooter(longToBinaryBlankString(trackedMessageId) + footerContent);
+>>>>>>> parent of 6a41e47... Update CommandCleanupListener.java
     }
 
     @Override

--- a/src/main/java/org/javacord/bot/listeners/CommandCleanupListener.java
+++ b/src/main/java/org/javacord/bot/listeners/CommandCleanupListener.java
@@ -26,7 +26,15 @@ public class CommandCleanupListener implements MessageDeleteListener {
     public static EmbedBuilder insertResponseTracker(EmbedBuilder builder, long trackedMessageId) {
         return  insertResponseTracker(builder, trackedMessageId, "If you delete your invocation message, this will be deleted. 🥄");
     }
-    
+
+    /**
+     * Inserts a tracking footer into an embed builder.
+     *
+     * @param builder          The embed builder to change.
+     * @param trackedMessageId The id of the message to track.
+     * @param footerContent The content the Footer should display.
+     * @return The embed builder for call chaining.
+     */
     public static EmbedBuilder insertResponseTracker(EmbedBuilder builder, long trackedMessageId, String footerContent) {
         return builder.setFooter(longToBinaryBlankString(trackedMessageId) + footerContent);
     }
@@ -46,7 +54,7 @@ public class CommandCleanupListener implements MessageDeleteListener {
         return message -> message.getCreationTimestamp().isAfter(instant);
     }
 
-  private Predicate<Message> isOurResponseTo(long messageId) {
+    private Predicate<Message> isOurResponseTo(long messageId) {
         String tracker = longToBinaryBlankString(messageId);
         return message -> !message.getEmbeds().isEmpty()
                 && message.getAuthor().isYourself()
@@ -55,8 +63,10 @@ public class CommandCleanupListener implements MessageDeleteListener {
                 .filter(text -> text.startsWith(tracker))
                 .isPresent();
     }
-    
+
     private static String longToBinaryBlankString(long l)  {
-        return Long.toBinaryString(l).replace('0', '\u200B').replace('1', '\u200D');
+        return Long.toBinaryString(l)
+                .replace('0', '\u200B')
+                .replace('1', '\u200D');
     }
 }

--- a/src/main/java/org/javacord/bot/listeners/CommandCleanupListener.java
+++ b/src/main/java/org/javacord/bot/listeners/CommandCleanupListener.java
@@ -7,6 +7,7 @@ import org.javacord.api.entity.message.embed.EmbedFooter;
 import org.javacord.api.event.message.MessageDeleteEvent;
 import org.javacord.api.listener.message.MessageDeleteListener;
 
+import java.util.Optional;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.function.Predicate;

--- a/src/main/java/org/javacord/bot/listeners/CommandCleanupListener.java
+++ b/src/main/java/org/javacord/bot/listeners/CommandCleanupListener.java
@@ -7,7 +7,6 @@ import org.javacord.api.entity.message.embed.EmbedFooter;
 import org.javacord.api.event.message.MessageDeleteEvent;
 import org.javacord.api.listener.message.MessageDeleteListener;
 
-import java.util.Optional;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.function.Predicate;
@@ -47,14 +46,14 @@ public class CommandCleanupListener implements MessageDeleteListener {
         return message -> message.getCreationTimestamp().isAfter(instant);
     }
 
-    private Predicate<Message> isOurResponseTo(long messageId) {
+  private Predicate<Message> isOurResponseTo(long messageId) {
         String tracker = longToBinaryBlankString(messageId);
         return message -> !message.getEmbeds().isEmpty()
                 && message.getAuthor().isYourself()
                 && message.getEmbeds().get(0).getFooter()
                 .flatMap(EmbedFooter::getText)
-                .flatMap(text -> Optional.of(text.startsWith(tracker)))
-                .orElse(false);
+                .filter(text -> text.startsWith(tracker))
+                .isPresent();
     }
     
     private static String longToBinaryBlankString(long l)  {

--- a/src/main/java/org/javacord/bot/listeners/CommandCleanupListener.java
+++ b/src/main/java/org/javacord/bot/listeners/CommandCleanupListener.java
@@ -24,21 +24,8 @@ public class CommandCleanupListener implements MessageDeleteListener {
      * @return The embed builder for call chaining.
      */
     public static EmbedBuilder insertResponseTracker(EmbedBuilder builder, long trackedMessageId) {
-        return  insertResponseTracker(builder, trackedMessageId,
-                "If you delete your invocation message, this will be deleted. 🥄");
-    }
-
-    /**
-     * Inserts a tracking footer into an embed builder.
-     *
-     * @param builder          The embed builder to change.
-     * @param trackedMessageId The id of the message to track.
-     * @param footerContent The content the Footer should display.
-     * @return The embed builder for call chaining.
-     */
-    public static EmbedBuilder insertResponseTracker(EmbedBuilder builder, long trackedMessageId, 
-                                                     String footerContent) {
-        return builder.setFooter(longToBinaryBlankString(trackedMessageId) + footerContent);
+        return builder.setFooter(longToBinaryBlankString(trackedMessageId)
+                                 + "If you delete your invocation message, this response will be deleted.");
     }
 
     @Override

--- a/src/main/java/org/javacord/bot/listeners/CommandCleanupListener.java
+++ b/src/main/java/org/javacord/bot/listeners/CommandCleanupListener.java
@@ -24,7 +24,8 @@ public class CommandCleanupListener implements MessageDeleteListener {
      * @return The embed builder for call chaining.
      */
     public static EmbedBuilder insertResponseTracker(EmbedBuilder builder, long trackedMessageId) {
-        return  insertResponseTracker(builder, trackedMessageId, "If you delete your invocation message, this will be deleted. 🥄");
+        return  insertResponseTracker(builder, trackedMessageId,
+                "If you delete your invocation message, this will be deleted. 🥄");
     }
 
     /**
@@ -35,7 +36,8 @@ public class CommandCleanupListener implements MessageDeleteListener {
      * @param footerContent The content the Footer should display.
      * @return The embed builder for call chaining.
      */
-    public static EmbedBuilder insertResponseTracker(EmbedBuilder builder, long trackedMessageId, String footerContent) {
+    public static EmbedBuilder insertResponseTracker(EmbedBuilder builder, long trackedMessageId, 
+                                                     String footerContent) {
         return builder.setFooter(longToBinaryBlankString(trackedMessageId) + footerContent);
     }
 

--- a/src/main/java/org/javacord/bot/listeners/CommandCleanupListener.java
+++ b/src/main/java/org/javacord/bot/listeners/CommandCleanupListener.java
@@ -24,7 +24,11 @@ public class CommandCleanupListener implements MessageDeleteListener {
      * @return The embed builder for call chaining.
      */
     public static EmbedBuilder insertResponseTracker(EmbedBuilder builder, long trackedMessageId) {
-        return builder.setFooter("re: " + trackedMessageId);
+        return  insertResponseTracker(builder, trackedMessageId, "If you delete your invocation message, this will be deleted. 🥄");
+    }
+    
+    public static EmbedBuilder insertResponseTracker(EmbedBuilder builder, long trackedMessageId, String footerContent) {
+        return builder.setFooter(longToBinaryBlankString(trackedMessageId) + footerContent);
     }
 
     @Override
@@ -43,14 +47,16 @@ public class CommandCleanupListener implements MessageDeleteListener {
     }
 
     private Predicate<Message> isOurResponseTo(long messageId) {
-        String tracker = "re: " + messageId;
+        String tracker = longToBinaryBlankString(messageId);
         return message -> !message.getEmbeds().isEmpty()
                 && message.getAuthor().isYourself()
                 && message.getEmbeds().get(0).getFooter()
                 .flatMap(EmbedFooter::getText)
-                .map(tracker::equals)
+                .flatMap(text -> Optional.of(text.startsWith(tracker)))
                 .orElse(false);
     }
-
-
+    
+    private static String longToBinaryBlankString(long l)  {
+        return Long.toBinaryString(l).replace('0', '\u200B').replace('1', '\u200D');
+    }
 }


### PR DESCRIPTION
This removes the "re: message_id" part from the EmbedFooter, and replaces it, with an useful text.