### PR TITLE
Update wiki parser for new wiki

### DIFF
--- a/src/main/java/org/javacord/bot/commands/WikiCommand.java
+++ b/src/main/java/org/javacord/bot/commands/WikiCommand.java
@@ -145,10 +145,14 @@ public class WikiCommand implements CommandExecutor {
             sentences++;
         }
         StringBuilder description = new StringBuilder()
-                .append(String.format("**[%s](%s)**\n\n", page.getTitle(), WikiParser.BASE_URL + page.getUrl()))
+                .append(String.format("**[%s](%s)**\n\n", page.getTitle(), WikiParser.BASE_URL + page.getPath()))
                 .append(cleanedDescription, 0, length + 1);
         if (length < cleanedDescription.length()) {
-            description.append("\n\n[*view full page*](").append(WikiParser.BASE_URL).append(page.getUrl()).append(")");
+            description
+                    .append("\n\n[*view full page*](")
+                    .append(WikiParser.BASE_URL)
+                    .append(page.getPath())
+                    .append(")");
         }
         embed.setDescription(description.toString());
     }

--- a/src/main/java/org/javacord/bot/util/wiki/parser/WikiPage.java
+++ b/src/main/java/org/javacord/bot/util/wiki/parser/WikiPage.java
@@ -7,7 +7,7 @@ public class WikiPage implements Comparable<WikiPage> {
 
     private final String title;
     private final String[] keywords;
-    private final String url;
+    private final String path;
     private final String content;
 
     /**
@@ -15,13 +15,13 @@ public class WikiPage implements Comparable<WikiPage> {
      *
      * @param title The title of the page.
      * @param keywords The keywords the page is tagged with.
-     * @param url The URL of the page, relative to the wiki's base URL.
+     * @param path The path of the page, relative to the wiki's base URL.
      * @param content The content of the page.
      */
-    public WikiPage(String title, String[] keywords, String url, String content) {
+    public WikiPage(String title, String[] keywords, String path, String content) {
         this.title = title;
         this.keywords = keywords;
-        this.url = url;
+        this.path = path;
         this.content = content;
     }
 
@@ -44,12 +44,12 @@ public class WikiPage implements Comparable<WikiPage> {
     }
 
     /**
-     * Gets the relative URL.
+     * Gets the relative path.
      *
-     * @return The page URL.
+     * @return The page path.
      */
-    public String getUrl() {
-        return url;
+    public String getPath() {
+        return path;
     }
 
     /**
@@ -67,7 +67,7 @@ public class WikiPage implements Comparable<WikiPage> {
      * @return The markdown for a link to the page.
      */
     public String asMarkdownLink() {
-        return String.format("[%s](%s)", title, WikiParser.BASE_URL + url);
+        return String.format("[%s](%s)", title, WikiParser.BASE_URL + path);
     }
 
     @Override

--- a/src/main/java/org/javacord/bot/util/wiki/parser/WikiParser.java
+++ b/src/main/java/org/javacord/bot/util/wiki/parser/WikiParser.java
@@ -19,7 +19,7 @@ import java.util.concurrent.CompletionException;
  */
 public class WikiParser {
 
-    public static final String API_URL = "https://javacord.org/api/wiki.json";
+    public static final String API_URL = "https://javacord.org/bot-search-index.json";
     public static final String BASE_URL = "https://javacord.org"; // the /wiki/ part of the url will be returned by the API
 
     private static final OkHttpClient client = new OkHttpClient();
@@ -82,11 +82,11 @@ public class WikiParser {
                 throw new AssertionError("Format of wiki page list not as expected");
             }
             for (JsonNode node : array) {
-                if (node.has("title") && node.has("keywords") && node.has("url") && node.has("content")) {
+                if (node.has("title") && node.has("keywords") && node.has("path") && node.has("content")) {
                     pages.add(new WikiPage(
                             node.get("title").asText(),
                             asStringArray(node.get("keywords")),
-                            node.get("url").asText(),
+                            node.get("path").asText(),
                             node.get("content").asText()
                     ));
                 } else {


### PR DESCRIPTION
The api endpoint for the new wiki changed and the response is slightly different.

This cannot be merged yes, because the new wiki is not live.
The current url of the new api is https://new.javacord.org/bot-search-index.json.