### PR TITLE
Allow only mentioned users (invoker and recipient) to trigger the slash command cleanup.

### DIFF
--- a/src/main/java/org/javacord/bot/listeners/SlashCommandCleanupListener.java
+++ b/src/main/java/org/javacord/bot/listeners/SlashCommandCleanupListener.java
@@ -6,6 +6,7 @@ import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import org.apache.logging.log4j.Logger;
 import org.javacord.api.DiscordApi;
+import org.javacord.api.entity.DiscordEntity;
 import org.javacord.api.event.message.reaction.ReactionAddEvent;
 import org.javacord.api.listener.message.reaction.ReactionAddListener;
 
@@ -46,6 +47,12 @@ public class SlashCommandCleanupListener implements ReactionAddListener {
                     }
 
                     if (!message.getReactionByEmoji(WASTEBASKET).orElseThrow(AssertionError::new).containsYou()) {
+                        return completedFuture(null);
+                    }
+
+                    if (message.getMentionedUsers().stream()
+                            .mapToLong(DiscordEntity::getId)
+                            .noneMatch(id -> id == event.getUserId())) {
                         return completedFuture(null);
                     }
 


### PR DESCRIPTION
This commit prevents other users to clean up a slash command response by clicking the wastebucket emoji by additionally checking if the reaction was added by an user who has been mentioned in the message prior.